### PR TITLE
(#48) ensure apps are correctly found by list

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -151,29 +150,24 @@ func (b *AppBuilder) listAction(_ *kingpin.ParseContext) error {
 	var found []string
 
 	for _, source := range sources {
-
 		if !fileExist(source) {
 			continue
 		}
 
-		err := filepath.Walk(source, func(path string, info fs.FileInfo, err error) error {
-			if err != nil {
-				return err
-			}
+		entries, err := os.ReadDir(source)
+		if err != nil {
+			return err
+		}
 
-			if strings.HasSuffix(info.Name(), "-app.yaml") {
-				abs, err := filepath.Abs(filepath.Join(source, info.Name()))
+		for _, entry := range entries {
+			if strings.HasSuffix(entry.Name(), "-app.yaml") {
+				abs := filepath.Join(source, entry.Name())
 				if err != nil {
 					return err
 				}
 
 				found = append(found, abs)
 			}
-
-			return nil
-		})
-		if err != nil {
-			return err
 		}
 	}
 

--- a/builder/templates.go
+++ b/builder/templates.go
@@ -41,9 +41,11 @@ func ParseStateTemplate(body string, args interface{}, flags interface{}, cfg in
 
 			return v, nil
 		},
+
 		"escape": func(v string) string {
 			return shellescape.Quote(v)
 		},
+
 		"read_file": func(v string) (string, error) {
 			b, err := os.ReadFile(v)
 			if err != nil {
@@ -52,6 +54,7 @@ func ParseStateTemplate(body string, args interface{}, flags interface{}, cfg in
 
 			return string(b), nil
 		},
+
 		"default": func(v interface{}, dflt string) string {
 			switch c := v.(type) {
 			case string:


### PR DESCRIPTION
Avoids using walk and abs, instead just get the
entries for a directory in the source list and
check whats there

Signed-off-by: R.I.Pienaar <rip@devco.net>