### PR TITLE
(#67) Support dry run in exec

### DIFF
--- a/builder/cli.go
+++ b/builder/cli.go
@@ -64,7 +64,7 @@ func createBuilder(ctx context.Context, name string, log Logger, opts ...Option)
 	if log == nil {
 		logger := logrus.New()
 		log = logrus.NewEntry(logger).WithField("app", name)
-		if os.Getenv("BUILDER_DEBUG") != "" {
+		if os.Getenv("BUILDER_DEBUG") != "" || os.Getenv("BUILDER_DRY_RUN") != "" {
 			logger.SetLevel(logrus.DebugLevel)
 		} else {
 			logger.SetLevel(logrus.WarnLevel)

--- a/docs/content/reference/exec.md
+++ b/docs/content/reference/exec.md
@@ -31,7 +31,9 @@ arguments:
 
 The `command` is how the shell command is specified and we show some [templating](../templating).  This will read the `.Config` hash for a value `Cowsay` if it does not exist it will default to `"cowsay"`. We also see how we can reference the `.Arguments` to access the value supplied by the user, we escape it for shell safety.
 
-We also show how to set environment variables using `environment`, this too will be templated. This was added in version `0.0.3`.
+We also show how to set environment variables using `environment`, this too will be templated.
+
+Since version `0.0.9` setting environment variable `BUILDER_DRY_RUN` to any value will enable debug logging, log the command and terminate without calling your command.
 
 ## Shell scripts
 


### PR DESCRIPTION
Set environment BUILDER_DRY_RUN=1 to enable
debug logging and prevent actual commands
from being run

Signed-off-by: R.I.Pienaar <rip@devco.net>